### PR TITLE
Fixed dimmer functionality

### DIFF
--- a/smartapps/light-control-v0.10.groovy
+++ b/smartapps/light-control-v0.10.groovy
@@ -113,11 +113,11 @@ def handleCommand(command, value) {
         }
     } else {
         whiteBulbs.each {
-            Integer currentLevel = it.currentValue("level")
+            String currentLevel = it.currentValue("level")
             log.debug "Set level of White Spectrum bulb $currentLevel -> $value"
         }
         rgbBulbs.each {
-            Integer currentLevel = it.currentValue("level")
+            String currentLevel = it.currentValue("level")
             log.debug "Set level of RGB bulb $currentLevel -> $value"
         }
         whiteBulbs*.setLevel(value as Integer)


### PR DESCRIPTION
Contrary to what the SmartThings documentation says, the return value of `level` is `String` rather than `Integer`. This fixes the behavior where turning the dial doesn't change the brightness level of the bulb.